### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(iomanager REQUIRED)
 find_package(logging REQUIRED)
 find_package(ers REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(fddetdataformats REQUIRED)
 find_package(readoutlibs REQUIRED)
 find_package(fdreadoutlibs REQUIRED)
 find_package(opmonlib REQUIRED)
@@ -21,7 +22,7 @@ find_package(opmonlib REQUIRED)
 daq_codegen(sspledcalibmodule.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 #daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 
-set(DUNEDAQ_DEPENDENCIES appfwk::appfwk readoutlibs::readoutlibs fdreadoutlibs::fdreadoutlibs detdataformats::detdataformats)
+set(DUNEDAQ_DEPENDENCIES appfwk::appfwk readoutlibs::readoutlibs fdreadoutlibs::fdreadoutlibs detdataformats::detdataformats fddetdataformats::fddetdataformats)
 
 # Provide override functionality for SSP dependencies
 #option(WITH_FTD2XX_AS_PACKAGE "SSP external (ftd2xx) as a dunedaq package" OFF)

--- a/cmake/sspmodulesConfig.cmake.in
+++ b/cmake/sspmodulesConfig.cmake.in
@@ -8,6 +8,7 @@ find_dependency(iomanager)
 find_dependency(logging)
 find_dependency(ers)
 find_dependency(detdataformats)
+find_dependency(fddetdataformats)
 find_dependency(readoutlibs)
 find_dependency(fdreadoutlibs)
 

--- a/src/SSPLEDCalibWrapper.cpp
+++ b/src/SSPLEDCalibWrapper.cpp
@@ -61,7 +61,7 @@ SSPLEDCalibWrapper::init(const data_t& args)
   //          configuration parameters that you're looking for in args aren't available since the args you're
   //          getting here is likely only *::Init data from the json file
 
-  m_device_interface = new dunedaq::sspmodules::DeviceInterface(dunedaq::detdataformats::ssp::kEthernet);
+  m_device_interface = new dunedaq::sspmodules::DeviceInterface(dunedaq::fddetdataformats::ssp::kEthernet);
   m_device_interface->Initialize(args);
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::init complete.";

--- a/src/SSPLEDCalibWrapper.hpp
+++ b/src/SSPLEDCalibWrapper.hpp
@@ -10,7 +10,7 @@
 
 #include "sspmodules/sspledcalibmodule/Nljs.hpp"
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "SSPIssues.hpp"
 #include "anlBoard/DeviceInterface.hpp"

--- a/src/anlBoard/DeviceInterface.cxx
+++ b/src/anlBoard/DeviceInterface.cxx
@@ -36,7 +36,7 @@ enum
 };
 
 // SSPDAQ::DeviceInterface::DeviceInterface(SSPDAQ::Comm_t commType, unsigned long deviceId)
-dunedaq::sspmodules::DeviceInterface::DeviceInterface(dunedaq::detdataformats::ssp::Comm_t commType)
+dunedaq::sspmodules::DeviceInterface::DeviceInterface(dunedaq::fddetdataformats::ssp::Comm_t commType)
   : fCommType(commType)
   , fDeviceId(0)
   , fState(dunedaq::sspmodules::DeviceInterface::kUninitialized)
@@ -67,9 +67,9 @@ dunedaq::sspmodules::DeviceInterface::OpenSlowControl()
   dunedaq::sspmodules::Device* device = 0;
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Opening "
-                              << ((fCommType == dunedaq::detdataformats::ssp::kUSB)
+                              << ((fCommType == dunedaq::fddetdataformats::ssp::kUSB)
                                     ? "USB"
-                                    : ((fCommType == dunedaq::detdataformats::ssp::kEthernet) ? "Ethernet" : "Emulated"))
+                                    : ((fCommType == dunedaq::fddetdataformats::ssp::kEthernet) ? "Ethernet" : "Emulated"))
                               << " device #" << fDeviceId << " for slow control only..." << std::endl;
 
   device = devman.OpenDevice(fCommType, fDeviceId, true);
@@ -521,7 +521,7 @@ dunedaq::sspmodules::DeviceInterface::BuildFragment(const dunedaq::sspmodules::T
 
   unsigned int dataSizeInWords = 0;
 
-  dataSizeInWords += dunedaq::detdataformats::ssp::MillisliceHeader::sizeInUInts;
+  dataSizeInWords += dunedaq::fddetdataformats::ssp::MillisliceHeader::sizeInUInts;
   for (auto ev = eventsToWrite.begin(); ev != eventsToWrite.end(); ++ev) {
     dataSizeInWords += (*ev)->header.length;
   }
@@ -530,7 +530,7 @@ dunedaq::sspmodules::DeviceInterface::BuildFragment(const dunedaq::sspmodules::T
   // Build slice header//
   //==================//
 
-  dunedaq::detdataformats::ssp::MillisliceHeader sliceHeader;
+  dunedaq::fddetdataformats::ssp::MillisliceHeader sliceHeader;
   sliceHeader.length = dataSizeInWords;
   sliceHeader.nTriggers = eventsToWrite.size();
   sliceHeader.startTime = theTrigger.startTime;
@@ -545,16 +545,16 @@ dunedaq::sspmodules::DeviceInterface::BuildFragment(const dunedaq::sspmodules::T
   fragmentData.resize(dataSizeInWords);
 
   static unsigned int headerSizeInWords =
-    sizeof(dunedaq::detdataformats::ssp::EventHeader) / sizeof(unsigned int); // Size of DAQ event header
+    sizeof(dunedaq::fddetdataformats::ssp::EventHeader) / sizeof(unsigned int); // Size of DAQ event header
 
   // Put millislice header at front of vector
   auto sliceDataPtr = fragmentData.begin();
   unsigned int* millisliceHeaderPtr = static_cast<unsigned int*>(static_cast<void*>(&sliceHeader));
   std::copy(
-    millisliceHeaderPtr, millisliceHeaderPtr + dunedaq::detdataformats::ssp::MillisliceHeader::sizeInUInts, sliceDataPtr);
+    millisliceHeaderPtr, millisliceHeaderPtr + dunedaq::fddetdataformats::ssp::MillisliceHeader::sizeInUInts, sliceDataPtr);
 
   // Fill rest of vector with event data
-  sliceDataPtr += dunedaq::detdataformats::ssp::MillisliceHeader::sizeInUInts;
+  sliceDataPtr += dunedaq::fddetdataformats::ssp::MillisliceHeader::sizeInUInts;
 
   for (auto ev = eventsToWrite.begin(); ev != eventsToWrite.end(); ++ev) {
     // DAQ event header
@@ -679,7 +679,7 @@ dunedaq::sspmodules::DeviceInterface::ReadEventFromDevice(EventPacket& event)
   unsigned int* headerBlock = (unsigned int*)&event.header;
   headerBlock[0] = 0xAAAAAAAA;
 
-  static const unsigned int headerReadSize = (sizeof(dunedaq::detdataformats::ssp::EventHeader) / sizeof(unsigned int) - 1);
+  static const unsigned int headerReadSize = (sizeof(dunedaq::fddetdataformats::ssp::EventHeader) / sizeof(unsigned int) - 1);
 
   // Wait for hardware queue to fill with full header data
   unsigned int timeWaited = 0; // in us
@@ -717,7 +717,7 @@ dunedaq::sspmodules::DeviceInterface::ReadEventFromDevice(EventPacket& event)
   std::copy(data.begin(), data.end(), &(headerBlock[1]));
 
   // Wait for hardware queue to fill with full event data
-  unsigned int bodyReadSize = event.header.length - (sizeof(dunedaq::detdataformats::ssp::EventHeader) / sizeof(unsigned int));
+  unsigned int bodyReadSize = event.header.length - (sizeof(dunedaq::fddetdataformats::ssp::EventHeader) / sizeof(unsigned int));
   queueLengthInUInts = 0;
   timeWaited = 0; // in us
 
@@ -752,7 +752,7 @@ dunedaq::sspmodules::DeviceInterface::ReadEventFromDevice(EventPacket& event)
   // Copy event data into event packet
   event.data = std::move(data);
 
-  auto ehsize = sizeof(struct dunedaq::detdataformats::ssp::EventHeader);
+  auto ehsize = sizeof(struct dunedaq::fddetdataformats::ssp::EventHeader);
   auto ehlength = event.header.length;
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Event data size: " << event.data.size() << " ehsize: " << ehsize
                               << " ehl: " << ehlength;
@@ -903,13 +903,13 @@ dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const nlohmann::json& ar
   std::stringstream ss;
   switch (interfaceTypeCode) {
     case 0:
-      fCommType = dunedaq::detdataformats::ssp::kUSB;
+      fCommType = dunedaq::fddetdataformats::ssp::kUSB;
       break;
     case 1:
-      fCommType = dunedaq::detdataformats::ssp::kEthernet;
+      fCommType = dunedaq::fddetdataformats::ssp::kEthernet;
       break;
     case 2:
-      fCommType = dunedaq::detdataformats::ssp::kEmulated;
+      fCommType = dunedaq::fddetdataformats::ssp::kEmulated;
       break;
     case 999:
       ss << "Error: Invalid interface type set (" << interfaceTypeCode << ")!" << std::endl;
@@ -921,7 +921,7 @@ dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const nlohmann::json& ar
       throw ConfigurationError(ERS_HERE, ss.str());
   }
   //
-  if (fCommType != dunedaq::detdataformats::ssp::kEthernet) {
+  if (fCommType != dunedaq::fddetdataformats::ssp::kEthernet) {
     fDeviceId = 0;
     std::stringstream ss;
     ss << "Error: Non-functioning interface type set: " << fCommType
@@ -938,9 +938,9 @@ dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const nlohmann::json& ar
   dunedaq::sspmodules::Device* device = 0;
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Configuring "
-                              << ((fCommType == dunedaq::detdataformats::ssp::kUSB)
+                              << ((fCommType == dunedaq::fddetdataformats::ssp::kUSB)
                                     ? "USB"
-                                    : ((fCommType == dunedaq::detdataformats::ssp::kEthernet) ? "Ethernet" : "Emulated"))
+                                    : ((fCommType == dunedaq::fddetdataformats::ssp::kEthernet) ? "Ethernet" : "Emulated"))
                               << " device #" << fDeviceId << "..." << std::endl;
 
   device = devman.OpenDevice(fCommType, fDeviceId);
@@ -1065,17 +1065,17 @@ dunedaq::sspmodules::DeviceInterface::GetIdentifier()
 
   std::string ident;
   ident += "SSP@";
-  if (fCommType == dunedaq::detdataformats::ssp::kUSB) {
+  if (fCommType == dunedaq::fddetdataformats::ssp::kUSB) {
     ident += "(USB";
     ident += fDeviceId;
     ident += "):";
-  } else if (fCommType == dunedaq::detdataformats::ssp::kEthernet) {
+  } else if (fCommType == dunedaq::fddetdataformats::ssp::kEthernet) {
     boost::asio::ip::address ip = boost::asio::ip::address_v4(fDeviceId);
     std::string ipString = ip.to_string();
     ident += "(";
     ident += ipString;
     ident += "):";
-  } else if (fCommType == dunedaq::detdataformats::ssp::kEmulated) {
+  } else if (fCommType == dunedaq::fddetdataformats::ssp::kEmulated) {
     ident += "(EMULATED";
     ident += fDeviceId;
     ident += "):";
@@ -1084,7 +1084,7 @@ dunedaq::sspmodules::DeviceInterface::GetIdentifier()
 }
 
 unsigned long                   // NOLINT(runtime/int)
-dunedaq::sspmodules::DeviceInterface::GetTimestamp(const dunedaq::detdataformats::ssp::EventHeader& header)
+dunedaq::sspmodules::DeviceInterface::GetTimestamp(const dunedaq::fddetdataformats::ssp::EventHeader& header)
 {
   unsigned long packetTime = 0; // NOLINT(runtime/int)
   TLOG_DEBUG(TLVL_WORK_STEPS) << "fUseExternalTimestamp value: " << std::boolalpha << fUseExternalTimestamp
@@ -1103,7 +1103,7 @@ dunedaq::sspmodules::DeviceInterface::GetTimestamp(const dunedaq::detdataformats
 }
 
 void
-dunedaq::sspmodules::DeviceInterface::SetExternalTimestamp(dunedaq::detdataformats::ssp::EventHeader& header, unsigned long newtimestamp)
+dunedaq::sspmodules::DeviceInterface::SetExternalTimestamp(dunedaq::fddetdataformats::ssp::EventHeader& header, unsigned long newtimestamp)
 {
   TLOG_DEBUG(TLVL_WORK_STEPS) << "fUseExternalTimestamp value: " << std::boolalpha << fUseExternalTimestamp
                               << std::endl;

--- a/src/anlBoard/DeviceInterface.hpp
+++ b/src/anlBoard/DeviceInterface.hpp
@@ -11,7 +11,7 @@
 #include "appfwk/app/Nljs.hpp"
 #include "iomanager/Sender.hpp"
 #include "fdreadoutlibs/SSPFrameTypeAdapter.hpp"
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 #include "logging/Logging.hpp"
 
 #include "DeviceManager.hpp"
@@ -49,7 +49,7 @@ public:
 
   //Just sets the fields needed to request the device.
   //Real work is done in Initialize which is called manually.
-  explicit DeviceInterface(dunedaq::detdataformats::ssp::Comm_t commType);
+  explicit DeviceInterface(dunedaq::fddetdataformats::ssp::Comm_t commType);
 
   ~DeviceInterface(){
     //if(fRequestReceiver){
@@ -176,7 +176,7 @@ private:
   Device* fDevice;
 
   //Whether we are using USB or Ethernet to connect to the device
-  dunedaq::detdataformats::ssp::Comm_t fCommType;
+  dunedaq::fddetdataformats::ssp::Comm_t fCommType;
 
   //Index of the device in the hardware-returned list
   unsigned long fDeviceId;    // NOLINT(runtime/int)
@@ -191,9 +191,9 @@ private:
 
   bool GetTriggerInfo(const EventPacket& event,dunedaq::sspmodules::TriggerInfo& newTrigger);
 
-  unsigned long GetTimestamp(const dunedaq::detdataformats::ssp::EventHeader& header);  // NOLINT(runtime/int)
+  unsigned long GetTimestamp(const dunedaq::fddetdataformats::ssp::EventHeader& header);  // NOLINT(runtime/int)
 
-  void SetExternalTimestamp(dunedaq::detdataformats::ssp::EventHeader& header, unsigned long newtimestamp);  // NOLINT(runtime/int)
+  void SetExternalTimestamp(dunedaq::fddetdataformats::ssp::EventHeader& header, unsigned long newtimestamp);  // NOLINT(runtime/int)
 
   //Build a millislice containing only a header and place in fQueue
   //    void BuildEmptyMillislice(unsigned long startTime,unsigned long endTime);

--- a/src/anlBoard/DeviceManager.cxx
+++ b/src/anlBoard/DeviceManager.cxx
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_DEVICEMANAGER_CXX_
 #define SSPMODULES_SRC_ANLBOARD_DEVICEMANAGER_CXX_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "DeviceManager.hpp"
 //#include "ftd2xx.h"
@@ -175,12 +175,12 @@ dunedaq::sspmodules::DeviceManager::RefreshDevices()
 }
 
 dunedaq::sspmodules::Device*
-dunedaq::sspmodules::DeviceManager::OpenDevice(dunedaq::detdataformats::ssp::Comm_t commType,
+dunedaq::sspmodules::DeviceManager::OpenDevice(dunedaq::fddetdataformats::ssp::Comm_t commType,
                                                unsigned int deviceNum,
                                                bool slowControlOnly)
 {
   // Check for devices if this hasn't yet been done
-  if (!fHaveLookedForDevices && commType != dunedaq::detdataformats::ssp::kEmulated) {
+  if (!fHaveLookedForDevices && commType != dunedaq::fddetdataformats::ssp::kEmulated) {
     this->RefreshDevices();
   }
 
@@ -200,7 +200,7 @@ dunedaq::sspmodules::DeviceManager::OpenDevice(dunedaq::detdataformats::ssp::Com
       //    }
       //    break;
       //
-    case dunedaq::detdataformats::ssp::kEthernet:
+    case dunedaq::fddetdataformats::ssp::kEthernet:
       if (fEthernetDevices.find(deviceNum) == fEthernetDevices.end()) {
         fEthernetDevices[deviceNum] = (std::move(
           std::unique_ptr<dunedaq::sspmodules::EthernetDevice>(new dunedaq::sspmodules::EthernetDevice(deviceNum))));
@@ -214,7 +214,7 @@ dunedaq::sspmodules::DeviceManager::OpenDevice(dunedaq::detdataformats::ssp::Com
       }
       break;
 
-    case dunedaq::detdataformats::ssp::kEmulated:
+    case dunedaq::fddetdataformats::ssp::kEmulated:
       while (fEmulatedDevices.size() <= deviceNum) {
         fEmulatedDevices.push_back(std::move(std::unique_ptr<dunedaq::sspmodules::EmulatedDevice>(
           new dunedaq::sspmodules::EmulatedDevice(fEmulatedDevices.size()))));

--- a/src/anlBoard/DeviceManager.hpp
+++ b/src/anlBoard/DeviceManager.hpp
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_DEVICEMANAGER_HPP_
 #define SSPMODULES_SRC_ANLBOARD_DEVICEMANAGER_HPP_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 //#include "ftd2xx.h"
 //#include "USBDevice.h"
@@ -39,7 +39,7 @@ public:
   //unsigned int GetNUSBDevices();
 
   //Open a device and return a pointer containing a handle to it
-  Device* OpenDevice(dunedaq::detdataformats::ssp::Comm_t commType,unsigned int deviceId,bool slowControlOnly=false);
+  Device* OpenDevice(dunedaq::fddetdataformats::ssp::Comm_t commType,unsigned int deviceId,bool slowControlOnly=false);
 
   //Interrogate FTDI for list of devices. GetNUSBDevices and OpenDevice will call this
   //if it has not yet been run, so it should not normally be necessary to call this directly.

--- a/src/anlBoard/EmulatedDevice.cxx
+++ b/src/anlBoard/EmulatedDevice.cxx
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_EMULATEDDEVICE_CXX_
 #define SSPMODULES_SRC_ANLBOARD_EMULATEDDEVICE_CXX_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "anlExceptions.hpp"
 #include "EmulatedDevice.hpp"
@@ -151,7 +151,7 @@ void dunedaq::sspmodules::EmulatedDevice::Stop(){
 void dunedaq::sspmodules::EmulatedDevice::EmulatorLoop(){
 
   //dune::DAQLogger::LogDebug("SSP_EmulatedDevice")<<"Starting emulator loop..."<<std::endl;
-  static unsigned int headerSizeInWords=sizeof(dunedaq::detdataformats::ssp::EventHeader)/sizeof(unsigned int);
+  static unsigned int headerSizeInWords=sizeof(dunedaq::fddetdataformats::ssp::EventHeader)/sizeof(unsigned int);
 
   //We want to generate events on random channels at random times
   std::default_random_engine generator;
@@ -171,7 +171,7 @@ void dunedaq::sspmodules::EmulatedDevice::EmulatorLoop(){
     int channel = channelDistribution(generator);
 
     //Build an event header. 
-    dunedaq::detdataformats::ssp::EventHeader header;
+    dunedaq::fddetdataformats::ssp::EventHeader header;
 
     //Standard header word
     header.header=0xAAAAAAAA;

--- a/src/anlBoard/EmulatedDevice.hpp
+++ b/src/anlBoard/EmulatedDevice.hpp
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_EMULATEDDEVICE_HPP_
 #define SSPMODULES_SRC_ANLBOARD_EMULATEDDEVICE_HPP_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "Device.hpp"
 #include "SafeQueue.hpp"

--- a/src/anlBoard/EthernetDevice.cxx
+++ b/src/anlBoard/EthernetDevice.cxx
@@ -102,18 +102,18 @@ dunedaq::sspmodules::EthernetDevice::DeviceReceive(std::vector<unsigned int>& da
 void
 dunedaq::sspmodules::EthernetDevice::DeviceRead(unsigned int address, unsigned int* value)
 {
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdRead;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdRead;
   tx.header.size = 1;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
 
   SendReceive(tx, rx, txSize, rxSizeExpected, 3);
   *value = rx.data[0];
@@ -122,19 +122,19 @@ dunedaq::sspmodules::EthernetDevice::DeviceRead(unsigned int address, unsigned i
 void
 dunedaq::sspmodules::EthernetDevice::DeviceReadMask(unsigned int address, unsigned int mask, unsigned int* value)
 {
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(uint);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(uint);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdReadMask;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdReadMask;
   tx.header.size = 1;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
   tx.data[0] = mask;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
 
   SendReceive(tx, rx, txSize, rxSizeExpected, 3);
   *value = rx.data[0];
@@ -143,19 +143,19 @@ dunedaq::sspmodules::EthernetDevice::DeviceReadMask(unsigned int address, unsign
 void
 dunedaq::sspmodules::EthernetDevice::DeviceWrite(unsigned int address, unsigned int value)
 {
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(uint);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(uint);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdWrite;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdWrite;
   tx.header.size = 1;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
   tx.data[0] = value;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
 
   SendReceive(tx, rx, txSize, rxSizeExpected, 3);
 }
@@ -163,20 +163,20 @@ dunedaq::sspmodules::EthernetDevice::DeviceWrite(unsigned int address, unsigned 
 void
 dunedaq::sspmodules::EthernetDevice::DeviceWriteMask(unsigned int address, unsigned int mask, unsigned int value)
 {
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + (sizeof(uint) * 2);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + (sizeof(uint) * 2);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdWriteMask;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdWriteMask;
   tx.header.size = 1;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
   tx.data[0] = mask;
   tx.data[1] = value;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * 2);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * 2);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + sizeof(unsigned int);
 
   SendReceive(tx, rx, txSize, rxSizeExpected, 3);
 }
@@ -197,18 +197,18 @@ void
 dunedaq::sspmodules::EthernetDevice::DeviceArrayRead(unsigned int address, unsigned int size, unsigned int* data)
 {
   unsigned int i = 0;
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdArrayRead;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdArrayRead;
   tx.header.size = size;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * size);
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * size);
 
   SendReceive(tx, rx, txSize, rxSizeExpected, 3);
   for (i = 0; i < rx.header.size; i++) {
@@ -220,18 +220,18 @@ void
 dunedaq::sspmodules::EthernetDevice::DeviceArrayWrite(unsigned int address, unsigned int size, unsigned int* data)
 {
   unsigned int i = 0;
-  dunedaq::detdataformats::ssp::CtrlPacket tx;
-  dunedaq::detdataformats::ssp::CtrlPacket rx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket tx;
+  dunedaq::fddetdataformats::ssp::CtrlPacket rx;
   unsigned int txSize;
   unsigned int rxSizeExpected;
 
-  tx.header.length = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + (sizeof(uint) * size);
+  tx.header.length = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + (sizeof(uint) * size);
   tx.header.address = address;
-  tx.header.command = dunedaq::detdataformats::ssp::cmdArrayWrite;
+  tx.header.command = dunedaq::fddetdataformats::ssp::cmdArrayWrite;
   tx.header.size = size;
-  tx.header.status = dunedaq::detdataformats::ssp::statusNoError;
-  txSize = sizeof(dunedaq::detdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * size);
-  rxSizeExpected = sizeof(dunedaq::detdataformats::ssp::CtrlHeader);
+  tx.header.status = dunedaq::fddetdataformats::ssp::statusNoError;
+  txSize = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader) + (sizeof(unsigned int) * size);
+  rxSizeExpected = sizeof(dunedaq::fddetdataformats::ssp::CtrlHeader);
 
   for (i = 0; i < size; i++) {
     tx.data[i] = data[i];
@@ -245,8 +245,8 @@ dunedaq::sspmodules::EthernetDevice::DeviceArrayWrite(unsigned int address, unsi
 //==============================================================================
 
 void
-dunedaq::sspmodules::EthernetDevice::SendReceive(dunedaq::detdataformats::ssp::CtrlPacket& tx,
-                                                 dunedaq::detdataformats::ssp::CtrlPacket& rx,
+dunedaq::sspmodules::EthernetDevice::SendReceive(dunedaq::fddetdataformats::ssp::CtrlPacket& tx,
+                                                 dunedaq::fddetdataformats::ssp::CtrlPacket& rx,
                                                  unsigned int txSize,
                                                  unsigned int rxSizeExpected,
                                                  unsigned int retryCount)
@@ -278,7 +278,7 @@ dunedaq::sspmodules::EthernetDevice::SendReceive(dunedaq::detdataformats::ssp::C
 }
 
 void
-dunedaq::sspmodules::EthernetDevice::SendEthernet(dunedaq::detdataformats::ssp::CtrlPacket& tx, unsigned int txSize)
+dunedaq::sspmodules::EthernetDevice::SendEthernet(dunedaq::fddetdataformats::ssp::CtrlPacket& tx, unsigned int txSize)
 {
   unsigned int txSizeWritten = fCommSocket.write_some(boost::asio::buffer(static_cast<void*>(&tx), txSize));
   if (txSizeWritten != txSize) {
@@ -287,7 +287,7 @@ dunedaq::sspmodules::EthernetDevice::SendEthernet(dunedaq::detdataformats::ssp::
 }
 
 void
-dunedaq::sspmodules::EthernetDevice::ReceiveEthernet(dunedaq::detdataformats::ssp::CtrlPacket& rx, unsigned int rxSizeExpected)
+dunedaq::sspmodules::EthernetDevice::ReceiveEthernet(dunedaq::fddetdataformats::ssp::CtrlPacket& rx, unsigned int rxSizeExpected)
 {
   unsigned int rxSizeReturned = fCommSocket.read_some(boost::asio::buffer(static_cast<void*>(&rx), rxSizeExpected));
   if (rxSizeReturned != rxSizeExpected) {

--- a/src/anlBoard/EthernetDevice.hpp
+++ b/src/anlBoard/EthernetDevice.hpp
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_ETHERNETDEVICE_HPP_
 #define SSPMODULES_SRC_ANLBOARD_ETHERNETDEVICE_HPP_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "Device.hpp"
 #include "boost/asio.hpp"
@@ -66,11 +66,11 @@ public:
 
   //Internal functions - make public so debugging code can access them
 
-  void SendReceive(dunedaq::detdataformats::ssp::CtrlPacket& tx, dunedaq::detdataformats::ssp::CtrlPacket& rx, unsigned int txSize, unsigned int rxSizeExpected, unsigned int retryCount=0);
+  void SendReceive(dunedaq::fddetdataformats::ssp::CtrlPacket& tx, dunedaq::fddetdataformats::ssp::CtrlPacket& rx, unsigned int txSize, unsigned int rxSizeExpected, unsigned int retryCount=0);
 
-  void SendEthernet(dunedaq::detdataformats::ssp::CtrlPacket& tx, unsigned int txSize);
+  void SendEthernet(dunedaq::fddetdataformats::ssp::CtrlPacket& tx, unsigned int txSize);
 
-  void ReceiveEthernet(dunedaq::detdataformats::ssp::CtrlPacket& rx, unsigned int rxSizeExpected);
+  void ReceiveEthernet(dunedaq::fddetdataformats::ssp::CtrlPacket& rx, unsigned int rxSizeExpected);
 
   void DevicePurge(boost::asio::ip::tcp::socket& socket);
 

--- a/src/anlBoard/EventPacket.hpp
+++ b/src/anlBoard/EventPacket.hpp
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_EVENTPACKET_HPP_
 #define SSPMODULES_SRC_ANLBOARD_EVENTPACKET_HPP_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include <vector>
 #include <sstream>
@@ -58,7 +58,7 @@ public:
 
   void DumpEvent();
 
-  dunedaq::detdataformats::ssp::EventHeader header;
+  dunedaq::fddetdataformats::ssp::EventHeader header;
 
   std::vector<unsigned int> data;
 };

--- a/src/anlBoard/RegMap.hpp
+++ b/src/anlBoard/RegMap.hpp
@@ -8,7 +8,7 @@
 #ifndef SSPMODULES_SRC_ANLBOARD_REGMAP_HPP_
 #define SSPMODULES_SRC_ANLBOARD_REGMAP_HPP_
 
-#include "detdataformats/ssp/SSPTypes.hpp"
+#include "fddetdataformats/SSPTypes.hpp"
 
 #include "anlExceptions.hpp"
 


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

