### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/src/SSPIssues.hpp
+++ b/src/SSPIssues.hpp
@@ -9,7 +9,7 @@
 #define SSPMODULES_SRC_SSPISSUES_HPP_
 
 #include <ers/Issue.hpp>
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/src/SSPIssues.hpp
+++ b/src/SSPIssues.hpp
@@ -9,6 +9,7 @@
 #define SSPMODULES_SRC_SSPISSUES_HPP_
 
 #include <ers/Issue.hpp>
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)