### PR TITLE
SSPLEDCalib: split of init to (proper) init + configure

### DIFF
--- a/plugins/SSPLEDCalibModule.cpp
+++ b/plugins/SSPLEDCalibModule.cpp
@@ -41,9 +41,10 @@ SSPLEDCalibModule::SSPLEDCalibModule(const std::string& name)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule constructor called.";
   m_card_wrapper = std::make_unique<SSPLEDCalibWrapper>();
 
+  register_command("conf", &SSPLEDCalibModule::do_configure);
   register_command("start", &SSPLEDCalibModule::do_start);
   register_command("stop", &SSPLEDCalibModule::do_stop);
-  
+
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule constructor complete.";
 }
 
@@ -52,10 +53,28 @@ SSPLEDCalibModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule init called.";
 
+  m_mcfg = mcfg;
   auto conf = mcfg->get_dal<appmodel::SSPLEDCalibModule>(get_name());
 
   m_card_wrapper->init(conf);
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule init complete.";
+}
+
+void
+SSPLEDCalibModule::do_configure(const data_t& /*args*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule conf called.";
+
+  if (!m_mcfg) {
+    std::stringstream ss;
+    ss << "Error: The configuration was not properly stored!" << std::endl;
+    throw ConfigurationError(ERS_HERE, ss.str());
+  }
+
+  auto conf = m_mcfg->get_dal<appmodel::SSPLEDCalibModule>(get_name());
+
+  m_card_wrapper->conf(conf);
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule conf complete.";
 }
 
 void

--- a/plugins/SSPLEDCalibModule.hpp
+++ b/plugins/SSPLEDCalibModule.hpp
@@ -40,8 +40,11 @@ public:
 private:
 
   // Commands
+  void do_configure(const data_t& /*args*/);
   void do_start(const data_t& args);
   void do_stop(const data_t& args);
+
+  std::shared_ptr<appfwk::ConfigurationManager> m_mcfg;
 
   // SSP Cards
   std::unique_ptr<SSPLEDCalibWrapper> m_card_wrapper;

--- a/src/SSPIssues.hpp
+++ b/src/SSPIssues.hpp
@@ -21,6 +21,11 @@ ERS_DECLARE_ISSUE(sspmodules,
 		  "LED calibration failed to configure",
 		  ERS_EMPTY)
 
+ERS_DECLARE_ISSUE(sspmodules,
+                  DeviceInterfacePDTSStatus,
+                  "Endpoint failed to reach 0x8",
+                  ERS_EMPTY)
+
 } // namespace dunedaq
 
 #endif // SSPMODULES_SRC_SSPISSUES_HPP_

--- a/src/SSPIssues.hpp
+++ b/src/SSPIssues.hpp
@@ -17,9 +17,14 @@ namespace dunedaq {
 ERS_DECLARE_ISSUE(sspmodules, ConfigurationError, "SSP Configuration Error: " << conferror, ((std::string)conferror))
 
 ERS_DECLARE_ISSUE(sspmodules,
-		  FailedLEDCalibration,
-		  "LED calibration failed to configure",
+		  FailedLEDCalibrationInit,
+		  "LED calibration failed to initialize",
 		  ERS_EMPTY)
+
+ERS_DECLARE_ISSUE(sspmodules,
+                  FailedLEDCalibrationConf,
+                  "LED calibration failed to configure",
+                  ERS_EMPTY)
 
 ERS_DECLARE_ISSUE(sspmodules,
                   DeviceInterfacePDTSStatus,

--- a/src/SSPLEDCalibWrapper.cpp
+++ b/src/SSPLEDCalibWrapper.cpp
@@ -73,11 +73,24 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
   try {
     m_device_interface->SetPartitionNumber(m_partition_number);
     m_device_interface->SetTimingAddress(m_timing_address);
+  } catch (const std::exception & e) {
+    throw FailedLEDCalibrationInit(ERS_HERE, e);
+  }
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::init complete.";
+}
+
+void
+SSPLEDCalibWrapper::conf(const appmodel::SSPLEDCalibModule* conf)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::conf called." << std::endl;
+
+  try {
     m_device_interface->ConfigureLEDCalib(conf); //This sets up the ethernet interface and make sure that the pdts is synched
     m_device_interface->SetRegisterByName("module_id", m_module_id);
     //m_device_interface->SetRegisterByName("eventDataInterfaceSelect", m_cfg.interface_type);
   } catch (const std::exception & e) {
-    throw FailedLEDCalibration(ERS_HERE, e);
+    throw FailedLEDCalibrationConf(ERS_HERE, e);
   }
 
   if ( conf->get_pulse_mode() == "single") {
@@ -86,7 +99,7 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
   } else if ( conf->get_pulse_mode() == "burst") {
     m_burst_mode = true;
     TLOG(TLVL_FULL_DEBUG) << "SSPLEDCalibWrapper: I think that you want SSP LED Calib module to be in BURST MODE..." << std::endl;
-  } 
+  }
 
   if ( (m_single_pulse && m_burst_mode) ) {
     std::stringstream ss;
@@ -94,7 +107,7 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
     TLOG() << ss.str();
     throw ConfigurationError(ERS_HERE, ss.str());
   }
-    
+
   if (m_burst_mode) {
     TLOG(TLVL_FULL_DEBUG) << "SSPLEDCalibWrapper: Configuring for BURST MODE..." << std::endl;
     this->configure_burst_mode();
@@ -106,14 +119,14 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
     ss << "ERROR: SOMEHOW ENDED UP WITH NO PULSE MODES SET ON!!!!" << std::endl;
     TLOG() << ss.str();
     throw ConfigurationError(ERS_HERE, ss.str());
-  }  
+  }
 
   //if there are "literal" entries in the configuration they are explicit writes to the specified register with given value
   //these literal entries are paresed and applied last after any other parameters so this method call needs to be after the
   //other configuration calls
   this->manual_configure_device(conf->get_hardware_configuration());
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::configure complete.";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::conf complete.";
 }
 
 void

--- a/src/SSPLEDCalibWrapper.hpp
+++ b/src/SSPLEDCalibWrapper.hpp
@@ -39,6 +39,7 @@ public:
 
   using data_t = nlohmann::json;
   void init(const appmodel::SSPLEDCalibModule* mcfg);
+  void conf(const appmodel::SSPLEDCalibModule* mcfg);
   void start(const data_t& args);
   void stop(const data_t& args);
   

--- a/src/anlBoard/DeviceInterface.cxx
+++ b/src/anlBoard/DeviceInterface.cxx
@@ -374,13 +374,20 @@ dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const appmodel::SSPLEDCa
     TLOG_DEBUG(TLVL_FULL_DEBUG) << "The pdts_status value is 0x" << std::hex << pdts_status
                                 << " and the 0xF bit masked value is 0x" << (pdts_status & 0xF) << std::dec << std::endl;
   }
+  int nTries = 0;
   while ((pdts_status & 0xF) != 0x8) {
+    if (nTries == 2) {
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "Wrong PDTS status!" << std::endl;
+      //ers::fatal( DeviceInterfacePDTSStatus(ERS_HERE) );
+      throw DeviceInterfacePDTSStatus(ERS_HERE);
+    }
     usleep(2000000);
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Woke up from 2 seconds of sleep and Waiting for endpoint to reach status 0x8..."
                                 << std::endl;
     fDevice->DeviceRead(duneReg.pdts_status, &pdts_status);
     TLOG_DEBUG(TLVL_FULL_DEBUG) << "The pdts_status value is 0x" << std::hex << pdts_status
                                 << " and the 0xF bit masked value is 0x" << (pdts_status & 0xF) << std::dec << std::endl;
+    nTries++;
   }
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << "Endpoint is in running state, continuing with configuration!" << std::endl;


### PR DESCRIPTION
Changes:

- SSPLEDCalibModule: splitting init to init + conf; propagation to wrapper
- SSPLEDCalibWrapper: splitting init to init + conf
- fix for an infinite loop in  anlBoard/DeviceInterface
- couple of new issues + corresponding throws

From online testing (log):
```
2025-Mar-31 14:50:08,490 DEBUG_5 [virtual void dunedaq::sspmodules::SSPLEDCalibModule::init(std::shared_ptr<dunedaq::appfwk::ConfigurationManager>) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/plugins/SSPLEDCalibModule.cpp:54] SSPLEDCalibModule init called.
2025-Mar-31 14:50:08,490 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::init(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:42] SSPLEDCalibWrapper::init called.
2025-Mar-31 14:50:08,490 DEBUG_10 [void dunedaq::sspmodules::SSPLEDCalibWrapper::init(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:68] Board ID is listed as: 999
Partition Number is: 0
Timing Address is: 32
Module ID is: 999
2025-Mar-31 14:50:08,490 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::init(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:80] SSPLEDCalibWrapper::init complete.
2025-Mar-31 14:50:08,490 DEBUG_5 [virtual void dunedaq::sspmodules::SSPLEDCalibModule::init(std::shared_ptr<dunedaq::appfwk::ConfigurationManager>) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/plugins/SSPLEDCalibModule.cpp:60] SSPLEDCalibModule init complete.
...
2025-Mar-31 14:50:28,617 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibModule::do_configure(const dunedaq::appfwk::DAQModule::data_t&) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/plugins/SSPLEDCalibModule.cpp:66] SSPLEDCalibModule conf called.
2025-Mar-31 14:50:28,617 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::conf(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:86] SSPLEDCalibWrapper::conf called.
2025-Mar-31 14:50:28,617 DEBUG_5 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:264] SSP LED Calib Device Interface Configure called.
2025-Mar-31 14:50:28,624 DEBUG_10 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:301] SSP HW presently on partition 0, address 0x20 with endpoint status 0x8 and dsp_clock_control at 0x11
2025-Mar-31 14:50:28,624 DEBUG_10 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:311] Clock already looks ok... skipping endpoint reset.
2025-Mar-31 14:50:28,624 DEBUG_10 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:369] Woke up from 2 seconds of sleep and Waiting for endpoint to reach status 0x8...
2025-Mar-31 14:50:28,624 DEBUG_10 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:393] Endpoint is in running state, continuing with configuration!
2025-Mar-31 14:50:28,624 DEBUG_5 [void dunedaq::sspmodules::DeviceInterface::ConfigureLEDCalib(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/anlBoard/DeviceInterface.cxx:394] SSP LED Calib Device Interface Configured complete.
2025-Mar-31 14:50:28,626 LOG [void dunedaq::sspmodules::SSPLEDCalibWrapper::conf(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:98] SSPLEDCalibWrapper: I think that you want SSP LED Calib module to be in single pulse...
2025-Mar-31 14:50:28,626 LOG [void dunedaq::sspmodules::SSPLEDCalibWrapper::conf(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:115] SSPLEDCalibWrapper: Configuring for single pulse mode...
2025-Mar-31 14:50:28,626 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::configure_single_pulse() at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:232] SSPLEDCalibWrapper::ConfigureSinglePulse called.
2025-Mar-31 14:50:28,671 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::configure_single_pulse() at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:255] SSPLEDCalibWrapper::ConfigureSinglePulse completed.
2025-Mar-31 14:50:28,671 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::manual_configure_device(const std::vector<const dunedaq::appmodel::SSPRegister*>&) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:290] SSPLEDCalibWrapper::ConfigureDevice called.
2025-Mar-31 14:50:28,671 LOG [void dunedaq::sspmodules::SSPLEDCalibWrapper::manual_configure_device(const std::vector<const dunedaq::appmodel::SSPRegister*>&) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:291] SSPLEDCalibWrapper: Processing the Hardware Configuration list...
2025-Mar-31 14:50:28,673 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::manual_configure_device(const std::vector<const dunedaq::appmodel::SSPRegister*>&) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:299] SSPLEDCalibWrapper::ConfigureDevice complete.
2025-Mar-31 14:50:28,673 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibWrapper::conf(const dunedaq::appmodel::SSPLEDCalibModule*) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/src/SSPLEDCalibWrapper.cpp:129] SSPLEDCalibWrapper::conf complete.
2025-Mar-31 14:50:28,673 DEBUG_5 [void dunedaq::sspmodules::SSPLEDCalibModule::do_configure(const dunedaq::appfwk::DAQModule::data_t&) at /nfs/home/mrigan/dune-daq/fddaq-v5.3.0-rc1-a9/sourcecode/sspmodules/plugins/SSPLEDCalibModule.cpp:77] SSPLEDCalibModule conf complete.
```

also passes typical integration tests (tested with `fddaq-v5.3.0-rc1-a9`): minimal_system_quick_test.py, small_footprint_quick_test.py, fake_data_producer_test.py, long_window_readout_test.py...
