### PR TITLE
LEDCalib: moving device initialization to conf

### DIFF
--- a/plugins/SSPLEDCalibModule.cpp
+++ b/plugins/SSPLEDCalibModule.cpp
@@ -54,9 +54,8 @@ SSPLEDCalibModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule init called.";
 
   m_mcfg = mcfg;
-  auto conf = mcfg->get_dal<appmodel::SSPLEDCalibModule>(get_name());
 
-  m_card_wrapper->init(conf);
+  //m_card_wrapper->init(conf); moved to conf for now
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule init complete.";
 }
 
@@ -73,6 +72,7 @@ SSPLEDCalibModule::do_configure(const data_t& /*args*/)
 
   auto conf = m_mcfg->get_dal<appmodel::SSPLEDCalibModule>(get_name());
 
+  m_card_wrapper->init(conf);
   m_card_wrapper->conf(conf);
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibModule conf complete.";
 }

--- a/src/SSPLEDCalibWrapper.cpp
+++ b/src/SSPLEDCalibWrapper.cpp
@@ -41,8 +41,6 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << "SSPLEDCalibWrapper::init called." << std::endl;
 
-  m_device_interface = new dunedaq::sspmodules::DeviceInterface();
-
   m_number_channels = conf->get_number_channels();
   m_channel_mask = conf->get_channel_mask();
   m_burst_count = conf->get_burst_count();
@@ -71,6 +69,7 @@ SSPLEDCalibWrapper::init(const appmodel::SSPLEDCalibModule* conf)
                               << "Module ID is: " << m_module_id << std::endl;
 
   try {
+    m_device_interface = new dunedaq::sspmodules::DeviceInterface();
     m_device_interface->SetPartitionNumber(m_partition_number);
     m_device_interface->SetTimingAddress(m_timing_address);
   } catch (const std::exception & e) {


### PR DESCRIPTION
As requested by @mroda88, moving the init call to conf block + moved `m_device_interface` assignment to try block.